### PR TITLE
prefer-arrow-callback 규칙을 off

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -46,5 +46,5 @@ module.exports = {
   'no-useless-constructor': 'error',
   'semi': ['error', 'never'],
   'sort-keys': 'off',
-  'prefer-arrow-callback': 'off',
+  'prefer-arrow-callback': ['error', { 'allowNamedFunctions': true }],
 }

--- a/rules/base.js
+++ b/rules/base.js
@@ -46,4 +46,5 @@ module.exports = {
   'no-useless-constructor': 'error',
   'semi': ['error', 'never'],
   'sort-keys': 'off',
+  'prefer-arrow-callback': 'off',
 }


### PR DESCRIPTION
https://www.notion.so/channelio/Hook-hook-3f96693ba2584cbdb9fa9f2968587cd8

```javascript
useEffect(() => {
  /* something */
}, [])
```
처럼 useEffect와 같이 기존에 익명함수를 인자로 넘기던 방식을 각 함수들의 의미를 명확하게 하기 위해 

```
useEffect(function something() {
   /* something */
}, [])
```
과 같이 사용하기 위해 prefer-arrow-callback lint를 비활성화