### PR TITLE
import type 구문을 항상 선호하도록 rule 추가

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -28,6 +28,7 @@ module.exports = {
   'import/no-extraneous-dependencies': 'off', // package.json directory hierarchy problem
   'import/order': ['error', { groups: ['external', 'builtin', 'internal', 'parent', 'sibling', 'index'] }],
   'import/prefer-default-export': 'off',
+  'import/no-named-defult': 'off',
   'max-len': ['error', 130],
   'new-cap': 'off',
   '@channel.io/no-classnames-with-one-argument': 'error',

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -1,5 +1,6 @@
 module.exports = {
   '@typescript-eslint/no-unused-vars': ['error'],
+  '@typescript-eslint/consistent-type-imports': ['error'],
   'no-dupe-class-members': 'off', // Allow method overriding (will be checked by tsc)
   'no-undef': 'off',
   'no-unused-vars': 'off',

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -1,6 +1,6 @@
 module.exports = {
   '@typescript-eslint/no-unused-vars': ['error'],
-  '@typescript-eslint/consistent-type-imports': ['error'],
+  '@typescript-eslint/consistent-type-imports': ['warn'],
   'no-dupe-class-members': 'off', // Allow method overriding (will be checked by tsc)
   'no-undef': 'off',
   'no-unused-vars': 'off',


### PR DESCRIPTION
- [Rule 개요](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/consistent-type-imports.md)

파일 내에서 type 으로밖에 사용되지 않는 변수는 TS 3.8에 도입된 type-only import으로 불러오도록 강제합니다.

> This option defines the expected import kind for type-only imports. Valid values for prefer are:
> 
> - **`type-imports` will enforce that you always use `import type Foo from '...'` except referenced by metadata of decorators. It is default.**
> - `no-type-imports` will enforce that you always use `import Foo from '...'.`

> Examples of correct code with {prefer: 'type-imports'}, and incorrect code with {prefer: 'no-type-imports'}.
```typescript
import type { Foo } from 'Foo';
import type Bar from 'Bar';
type T = Foo;
const x: Bar = 1;
```

> Examples of incorrect code with {prefer: 'type-imports'}, and correct code with {prefer: 'no-type-imports'}.

```typescript
import { Foo } from 'Foo';
import Bar from 'Bar';
type T = Foo;
const x: Bar = 1;
```

type-only import은 컴파일 이후 사라지기 때문에 모듈 간의 불필요한 의존성이 줄어듭니다. 이로 인해 dependency graph가 간결해져 코드 스플리팅을 적용했을 때 번들 간 중복되는 코드가 줄어듭니다.