### PR TITLE
react rule 에 jsx-key 추가

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -1,6 +1,7 @@
 module.exports = {
   'react-hooks/exhaustive-deps': 'error', // Checks effect dependencies
   'react-hooks/rules-of-hooks': 'error', // Checks rules of Hooks
+  'react/jsx-key': 'error', // Checks required key prop in JSX exist
   'react/default-props-match-prop-types': 'off', // See: https://github.com/yannickcr/eslint-plugin-react/issues/2396
   'react/destructuring-assignment': ['warn', 'always'],
   'react/forbid-prop-types': 'off',

--- a/rules/react.js
+++ b/rules/react.js
@@ -1,7 +1,7 @@
 module.exports = {
   'react-hooks/exhaustive-deps': 'error', // Checks effect dependencies
   'react-hooks/rules-of-hooks': 'error', // Checks rules of Hooks
-  'react/jsx-key': 'error', // Checks required key prop in JSX exist
+  'react/jsx-key': 'warn', // Checks required key prop in JSX exist
   'react/default-props-match-prop-types': 'off', // See: https://github.com/yannickcr/eslint-plugin-react/issues/2396
   'react/destructuring-assignment': ['warn', 'always'],
   'react/forbid-prop-types': 'off',

--- a/rules/react.js
+++ b/rules/react.js
@@ -1,7 +1,7 @@
 module.exports = {
   'react-hooks/exhaustive-deps': 'error', // Checks effect dependencies
   'react-hooks/rules-of-hooks': 'error', // Checks rules of Hooks
-  'react/jsx-key': 'warn', // Checks required key prop in JSX exist
+  'react/jsx-key': 'warn', // TODO: (@axel) 사용처 버전업 진행 후 error 레벨로 변경. // Checks required key prop in JSX exist
   'react/default-props-match-prop-types': 'off', // See: https://github.com/yannickcr/eslint-plugin-react/issues/2396
   'react/destructuring-assignment': ['warn', 'always'],
   'react/forbid-prop-types': 'off',


### PR DESCRIPTION
JSX 문에서 map() 등의 iterate 메소드를 써서 컴포넌트를 렌더할 때 key prop 을 놓치지 않게 하는
**react/jsx-key** rule 을 **error** 레벨로 추가했습니다.

=> 점진적 마이그레이션을 위해 **warn** 레벨 으로 수정