### PR TITLE
업데이트: react/jsx-key - error 레벨로 변경하고 만연한 옵션들 기본값 추가

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -1,7 +1,10 @@
 module.exports = {
   'react-hooks/exhaustive-deps': 'error', // Checks effect dependencies
   'react-hooks/rules-of-hooks': 'error', // Checks rules of Hooks
-  'react/jsx-key': 'warn', // TODO: (@axel) 사용처 버전업 진행 후 error 레벨로 변경. // Checks required key prop in JSX exist
+  'react/jsx-key': ['error', {
+    checkFragmentShorthand: true,
+    checkKeyMustBeforeSpread: true,
+  }],
   'react/default-props-match-prop-types': 'off', // See: https://github.com/yannickcr/eslint-plugin-react/issues/2396
   'react/destructuring-assignment': ['warn', 'always'],
   'react/forbid-prop-types': 'off',


### PR DESCRIPTION
# Summary
[v1.3.0](https://github.com/channel-io/eslint-config/releases/tag/v1.3.0) 에서 추가 된 `react/jsx-key` 옵션을 `error` 레벨로 변경하고, 제공되는 옵션들의 기본값을 변경하였습니다.

# Details
- 레벨 변경: `warn` → `error`
- **`checkFragmentShorthand`**: `false`(기본값) → `true`
  > This option was added to avoid a breaking change and will be the default in the next major version.
  ```typescript
  // (correct) '<>' shorthand를 사용 할 때에도 key를 넣어주어야 함
  data.map((x, i) => <key={i}>{x}</>)
  ```
- **`checkKeyMustBeforeSpread`**: `false`(기본값) → `true`
  ```typescript
  // (incorrect) key prop이 spreading보다 앞으로 와야 함
  <span {...spread} key={"key-after-spread"} />
  ```

# References
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md