### PR TITLE
.gitignore - .idea 디렉터리 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ tags
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff
+.idea
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/**/usage.statistics.xml


### PR DESCRIPTION
# Summary
`.idea`를 추가합니다. 그동안 하위 경로(ex: `.idea/**/...`)는 추가되어 있었으나 최상위 디렉터리가 지정되어 있지 않았으므로 계속 감지가 되지 않았기에, 추가합니다.

# Details
```diff
+ .idea
```

# References
(참고 문서)
