### PR TITLE
no-named-default 오타로 제대로 작동되고 있지 않던 설정 수정

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -28,7 +28,7 @@ module.exports = {
   'import/no-extraneous-dependencies': 'off', // package.json directory hierarchy problem
   'import/order': ['error', { groups: ['external', 'builtin', 'internal', 'parent', 'sibling', 'index'] }],
   'import/prefer-default-export': 'off',
-  'import/no-named-defult': 'off',
+  'import/no-named-default': 'off',
   'max-len': ['error', 130],
   'new-cap': 'off',
   '@channel.io/no-classnames-with-one-argument': 'error',


### PR DESCRIPTION
# Summary
import type은 default와 나머지를 한 줄에 작성이 불가합니다.
```ts
import type Foo, { Bar } from './foo' // typescript error

// alternative 1: 
import type { default as Foo, Bar } from './foo' // eslint import/no-named-default error

// alternative 2:
import type Foo from './foo'
import type { Bar } from './foo' // eslint import/no-duplicates error
```

그래서 위 대안 중 1번과 같이 작성하고 desk-web에서 import/no-named-default를 ignore하고 있는 경우가 많습니다.
```ts
// eslint-disable-next-line import/no-named-default
import type { default as Foo, Bar } from './foo'
```

그래서 이걸 rule에서 제외하고자 #25 에서 작업하셨는데 오타가 있어서 제대로 작동되고 있지 않았습니다.

따라서 이 문제를 수정합니다.