### PR TITLE
max-len rule off로 세팅

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -29,7 +29,7 @@ module.exports = {
   'import/order': ['error', { groups: ['external', 'builtin', 'internal', 'parent', 'sibling', 'index'] }],
   'import/prefer-default-export': 'off',
   'import/no-named-default': 'off',
-  'max-len': ['error', 130],
+  'max-len': 'off', /** @todo apply prettier */
   'new-cap': 'off',
   '@channel.io/no-classnames-with-one-argument': 'error',
   'no-console': 'error',

--- a/rules/base.js
+++ b/rules/base.js
@@ -29,7 +29,7 @@ module.exports = {
   'import/order': ['error', { groups: ['external', 'builtin', 'internal', 'parent', 'sibling', 'index'] }],
   'import/prefer-default-export': 'off',
   'import/no-named-default': 'off',
-  'max-len': 'off', /** @todo apply prettier */
+  'max-len': 'off',
   'new-cap': 'off',
   '@channel.io/no-classnames-with-one-argument': 'error',
   'no-console': 'error',


### PR DESCRIPTION
# Summary
- max-len rule을 off로 세팅합니다

# Details
- eslint의 max-len rule은 단지 error만 표시해주고 자동 개행 처리 기능이 없습니다
- 자동변환 없이 개발자가 직접 개행해야 하므로, 개행 여부도 개발자들에게 위임을 제안합니다
- 현재 eslint max-len rule은 error로 설정되어 커밋시 eslint 테스트가 실패합니다
- 코드가 길어질 수밖에 없는 경우 eslint max-len 설정으로 불필요한 코드 주석이 많아지고, 개발시 병목을 발생시킵니다.
  - 예시 : 긴 링크가 들어간 주석, svg 코드, actionCreator 코드

# References
- [관련 스레드](https://desk.channel.io/root/threads/groups/Web-18500/62c282244d750a1b0b37/62c282244d750a1b0b37)
