### PR TITLE
peerDependency > typescript-eslint > 버전 업그레이드 (v4 -> v5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "license": "MIT",
   "peerDependencies": {
     "@channel.io/eslint-plugin": "^1.2.0",
-    "@typescript-eslint/eslint-plugin": "^4.4.1",
-    "@typescript-eslint/parser": "^4.4.1",
+    "@typescript-eslint/eslint-plugin": "^5.35.1",
+    "@typescript-eslint/parser": "^5.35.1",
     "babel-eslint": "^8.2.6",
     "eslint": "^7.0.0",
     "eslint-config-airbnb-typescript": "^12.0.0",


### PR DESCRIPTION
# Summary
- 프론트, 데스크 모두 현재 v5를 사용중입니다
- npm v7부터는 peer dependancy 버전이 맞지 않으면 패키지 설치가 되지 않습니다

# Details
- (수정 내용에 대한 상세 내용)

# References
(참고 문서)
