### PR TITLE
update peerDepedency of @typescript-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "license": "MIT",
   "peerDependencies": {
     "@channel.io/eslint-plugin": "^1.2.0",
-    "@typescript-eslint/eslint-plugin": "^5.35.1",
-    "@typescript-eslint/parser": "^5.35.1",
+    "@typescript-eslint/eslint-plugin": "^5.44.0",
+    "@typescript-eslint/parser": "^5.44.0",
     "babel-eslint": "^8.2.6",
     "eslint": "^7.0.0",
     "eslint-config-airbnb-typescript": "^12.0.0",


### PR DESCRIPTION
# Summary
@typescript-eslint peer dependency를 최신 버전으로 업데이트합니다.

# Details
- #64 typescript를 ^4.9 버전으로 올리면 satisfies 문법 사용이 가능해지는데, @typescript-eslint 에서는 satisfies 문법을 ^5.44.0에서 지원합니다.
- 사용처(plugin, desk)에서도 @typescript-eslint를 5.44.0 으로 업데이트 해주어야 합니다.

# References
- https://github.com/typescript-eslint/typescript-eslint/releases/tag/v5.44.0