### PR TITLE
no-translate-with-template-literal 을 error로 수정

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -41,7 +41,7 @@ module.exports = {
   'no-param-reassign': ['error', { props: false }],
   'no-restricted-imports': ['error', { paths: ['src'], patterns: ['../*'], }],
   'no-restricted-modules': ['error', { paths: ['src'], patterns: ['../*'], }],
-  '@channel.io/no-translate-with-template-literal': 'warn',
+  '@channel.io/no-translate-with-template-literal': 'error',
   'no-underscore-dangle': 'off',
   'no-unused-expressions': 'off', // use babel/no-unused-expressions
   'no-unused-vars': ['error', { ignoreRestSiblings: true }],


### PR DESCRIPTION
# Summary
no-translate-with-template-literal 을 아예 사용하지 못하게 강제합니다.

# Details
해당 룰은 translate() 함수에 template literal 문법을 사용하지 못하게 합니다.
ex
```typescript

const today: Day = Day.Mon // 'mon'

const TranslateMap: Record<Day, TranslateKey> = {]
  [Day.Mon]: 'ch.mon',
  ...
}

// bad ❌
translate(`ch.${today}`)
// good ✅
translate(TranslateMap[today])
```

# References
- [관련 스레드](https://desk.channel.io/root/threads/groups/WebFrontDev-82762/63d7854fc3b66a3f3780/63d7854fc3b66a3f3780)
- https://github.com/channel-io/ch-desk-web/pull/12184
