### PR TITLE
fix: warn off for props no spreading

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -12,7 +12,7 @@ module.exports = {
   'react/jsx-filename-extension': ['warn', { extensions: ['.js', '.jsx', '.tsx'] }],
   'react/jsx-no-constructed-context-values': 'error',
   'react/jsx-no-target-blank': 'off',
-  'react/jsx-props-no-spreading': 'warn',
+  'react/jsx-props-no-spreading': 'off',
   'react/no-did-update-set-state': 'off', // Some are not alternative
   'react/no-find-dom-node': 'off',
   'react/prefer-stateless-function': 'off',


### PR DESCRIPTION
# Summary

'react/jsx-props-no-spreading' 규칙을 끕니다.


# Details

이 규칙을 회피하여 코드를 작성하는것이 아닌, 단순히 eslint-disable을 통해 해결하는 경우가 대부분이라 의미가 크지 않다고 판단하여 삭제합니다.

# References
프론트 공유 쓰레드: https://desk.channel.io/root/groups/WebFrontDev-82762/6510e30ae8b3444fc7f1
Research Notion: https://www.notion.so/channelio/03833720effe4a1e8c279f26478a69c6?v=094a0a4cfbb94d5f928f4b6c059b7fd0&p=d0d5feb562db41d289a6cb79e1b531ee&pm=s